### PR TITLE
Handle '/dev/stdout' in Logger Configuration

### DIFF
--- a/cmdb-api/api/app.py
+++ b/cmdb-api/api/app.py
@@ -192,10 +192,11 @@ def configure_logger(app):
         app.logger.addHandler(handler)
 
     log_file = app.config['LOG_PATH']
-    file_handler = RotatingFileHandler(log_file,
-                                       maxBytes=2 ** 30,
-                                       backupCount=7)
-    file_handler.setLevel(getattr(logging, app.config['LOG_LEVEL']))
-    file_handler.setFormatter(formatter)
-    app.logger.addHandler(file_handler)
+    if log_file and log_file != "/dev/stdout":
+        file_handler = RotatingFileHandler(log_file,
+                                           maxBytes=2 ** 30,
+                                           backupCount=7)
+        file_handler.setLevel(getattr(logging, app.config['LOG_LEVEL']))
+        file_handler.setFormatter(formatter)
+        app.logger.addHandler(file_handler)
     app.logger.setLevel(getattr(logging, app.config['LOG_LEVEL']))


### PR DESCRIPTION
This MR updates the logger configuration to handle the case when 'LOG_PATH' is set to '/dev/stdout'. It checks whether the 'LOG_PATH' is '/dev/stdout' or empty, and if so, it only logs to stdout and does not attempt to create a file handler. This prevents the 'underlying stream is not seekable' error when trying to log to '/dev/stdout'.

PS: For K8S logs system