### PR TITLE
[更新] 修复 LDAP 登录失败的问题

### DIFF
--- a/cmdb-api/api/lib/perm/authentication/ldap.py
+++ b/cmdb-api/api/lib/perm/authentication/ldap.py
@@ -23,13 +23,13 @@ from api.models.acl import User
 def authenticate_with_ldap(username, password):
     config = AuthenticateDataCRUD(AuthenticateType.LDAP).get()
 
-    server = Server(config.get('LDAP').get('ldap_server'), get_info=ALL, connect_timeout=3)
+    server = Server(config.get('ldap_server'), get_info=ALL, connect_timeout=3)
     if '@' in username:
         email = username
-        who = config['LDAP'].get('ldap_user_dn').format(username.split('@')[0])
+        who = config.get('ldap_user_dn').format(username.split('@')[0])
     else:
-        who = config['LDAP'].get('ldap_user_dn').format(username)
-        email = "{}@{}".format(who, config['LDAP'].get('ldap_domain'))
+        who = config.get('ldap_user_dn').format(username)
+        email = "{}@{}".format(who, config.get('ldap_domain'))
 
     username = username.split('@')[0]
     user = User.query.get_by_username(username)
@@ -41,7 +41,7 @@ def authenticate_with_ldap(username, password):
             conn = Connection(server, user=who, password=password, auto_bind=AUTO_BIND_NO_TLS)
         except LDAPBindError:
             conn = Connection(server,
-                              user=f"{username}@{config['LDAP'].get('ldap_domain')}",
+                              user=f"{username}@{config.get('ldap_domain')}",
                               password=password,
                               auto_bind=AUTO_BIND_NO_TLS)
 

--- a/cmdb-api/api/views/acl/login.py
+++ b/cmdb-api/api/views/acl/login.py
@@ -39,7 +39,7 @@ class LoginView(APIView):
         password = request.values.get("password")
         _role = None
         config = AuthenticateDataCRUD(AuthenticateType.LDAP).get()
-        if config.get('LDAP', {}).get('enabled') or config.get('LDAP', {}).get('enable'):
+        if config.get('enabled') or config.get('enable'):
             from api.lib.perm.authentication.ldap import authenticate_with_ldap
             user, authenticated = authenticate_with_ldap(username, password)
         else:


### PR DESCRIPTION
ldap 登录提示密码错误。打印 config 信息如下：
/data/apps/cmdb/api/views/acl/login.py 42 - {'enable': 1, 'ldap_domain': 'baidu.com', 'ldap_server': 'ldap://ldap.baidu.com:389', 'ldap_user_dn': 'uid={},ou=people,dc=baidu,dc=com'}

但是代码里面多处调用如下： config['LDAP'].get("ldap_domain")，实际没有 LDAP 的 key, 修改为 config.get("ldap_domain")