### PR TITLE
修复在用了计算属性的情况下,批量上传功能可能出现的错误.

### DIFF
--- a/cmdb-api/api/lib/cmdb/ci.py
+++ b/cmdb-api/api/lib/cmdb/ci.py
@@ -328,7 +328,8 @@ class CIManager(object):
         ci_type_attrs_name = {attr.name: attr for _, attr in attrs}
         ci_type_attrs_alias = {attr.alias: attr for _, attr in attrs}
         ci_attr2type_attr = {type_attr.attr_id: type_attr for type_attr, _ in attrs}
-
+        ci_type_attrs_name_alias = {**ci_type_attrs_name, **ci_type_attrs_alias}
+        
         ci = None
         record_id = None
         password_dict = {}
@@ -412,7 +413,7 @@ class CIManager(object):
                     else:
                         ci_dict.pop(k)
 
-            ci_dict = {k: v for k, v in ci_dict.items() if k in ci_type_attrs_name or k in ci_type_attrs_alias}
+            ci_dict = {ci_type_attrs_name_alias[k].name: v for k, v in ci_dict.items() if k in ci_type_attrs_name_alias}
 
             key2attr = value_manager.valid_attr_value(ci_dict, ci_type.id, ci and ci.id,
                                                       ci_type_attrs_name, ci_type_attrs_alias, ci_attr2type_attr)


### PR DESCRIPTION
当模型中使用了计算属性,在批量上传时可能会出现部分错误.
1.当计算属性为普通的引用,例如{{sysname}}_{{cvmname}}_ci,在导入的数据中sysname\cvmname都有值的情况下,该计算属性的结果可能为"__ci",重新触发计算后才生效;
2.当计算属性为复杂的引用,例如{{sysname.split('|')[0]}},在导入的数据中sysname有值的情况下,会提示导入失败,sysname的值未定义;
以上问题,使用资源数据模块来单个新增则正常,查看批量导入的代码以及后端API的代码,主要原因在于:
批量导入时,使用的是CI的别名,而单个新增时,传入的则是CI名称,所以导致结果存在差异;
修复建议:
为对齐逻辑,建议在后端代码中,将别名装为名称后,再继续传参.