### PR TITLE
bugfix: cmdb-api  auto_discovery add unique_value param

### DIFF
--- a/cmdb-api/api/views/cmdb/auto_discovery.py
+++ b/cmdb-api/api/views/cmdb/auto_discovery.py
@@ -225,6 +225,7 @@ class AutoDiscoveryCIView(APIView):
     @args_required("type_id")
     @args_required("adt_id")
     @args_required("instance")
+    @args_required("unique_value")
     def post(self):
         request.values.pop("_key", None)
         request.values.pop("_secret", None)


### PR DESCRIPTION
自动发现接口需要根据unique_value参数进行数据唯一性校验，此参数为必填项