### PR TITLE
fix(search): correct type_id usage in CI relation filtering

### DIFF
--- a/cmdb-api/api/lib/cmdb/search/ci_relation/search.py
+++ b/cmdb-api/api/lib/cmdb/search/ci_relation/search.py
@@ -391,9 +391,10 @@ class Search(object):
             id2children[str(i)] = item['children']
 
         for lv in range(1, self.level):
+            type_id = type_ids[lv]
 
-            if len(type_ids or []) >= lv and type2filter_perms.get(type_ids[lv]):
-                id_filter_limit, _ = self._get_ci_filter(type2filter_perms[type_ids[lv]])
+            if len(type_ids or []) >= lv and type2filter_perms.get(type_id):
+                id_filter_limit, _ = self._get_ci_filter(type2filter_perms[type_id])
             else:
                 id_filter_limit = {}
 
@@ -401,12 +402,12 @@ class Search(object):
                 key, prefix = [i for i in level_ids], REDIS_PREFIX_CI_RELATION2
             else:
                 key, prefix = [i.split(',')[-1] for i in level_ids], REDIS_PREFIX_CI_RELATION
+            
             res = [json.loads(x).items() for x in [i or '{}' for i in rd.get(key, prefix) or []]]
-            res = [[i for i in x if (not id_filter_limit or (key[idx] not in id_filter_limit or
+            res = [[i for i in x if i[1] == type_id and (not id_filter_limit or (key[idx] not in id_filter_limit or
                                                              int(i[0]) in id_filter_limit[key[idx]]) or
                                      int(i[0]) in id_filter_limit)] for idx, x in enumerate(res)]
             _level_ids = []
-            type_id = type_ids[lv]
             id2name = _get_id2name(type_id)
             for idx, node_path in enumerate(level_ids):
                 for child_id, _ in (res[idx] or []):


### PR DESCRIPTION
问题：接口https://[cmdb.veops.cn/api/v0.1/ci_relations/search/full?level=2&root_ids=5&has_m2m=1&type_ids=1,2](https://cmdb.veops.cn/api/v0.1/ci_relations/search/full?level=2&root_ids=5&has_m2m=1&type_ids=1,2)
在获取层级关系时，如果父CITYPE关联的两个子CITYPE的唯一标识字段一致，使用该接口获取数据时，会出现错乱。以type_ids=1,2为例，原意是要获取1，2两个CITYPE的2层关系，但通过该接口会获取到已关联的其他子CITYPE的数据。
修复方式：具体见代码。