### PR TITLE
fix(api): 使用 ast.literal_eval 代替 eval,取消不正确的计算属性值返回。

### DIFF
--- a/cmdb-api/api/lib/cmdb/value.py
+++ b/cmdb-api/api/lib/cmdb/value.py
@@ -10,6 +10,7 @@ import jinja2
 import os
 import re
 import tempfile
+import ast
 from flask import abort
 from flask import current_app
 from jinja2schema import infer
@@ -180,13 +181,14 @@ class AttributeValueManager(object):
 
     @staticmethod
     def _compute_attr_value_from_expr(expr, ci_dict):
-        t = jinja2.Template(expr).render(ci_dict)
-
+        result = jinja2.Template(expr).render(ci_dict)
         try:
-            return eval(t)
+            return ast.literal_eval(result)
         except Exception as e:
-            current_app.logger.warning(str(e))
-            return t
+            current_app.logger.warning(
+                f"Expression evaluation error - Expression: '{expr}', Rendered result: '{result}', "
+                f"Input parameters: {ci_dict}, Error type: {type(e).__name__}, Error message: {str(e)}"
+            )
 
     @staticmethod
     def _compute_attr_value_from_script(script, ci_dict):

--- a/cmdb-api/api/lib/cmdb/value.py
+++ b/cmdb-api/api/lib/cmdb/value.py
@@ -10,7 +10,6 @@ import jinja2
 import os
 import re
 import tempfile
-import ast
 from flask import abort
 from flask import current_app
 from jinja2schema import infer
@@ -181,15 +180,15 @@ class AttributeValueManager(object):
 
     @staticmethod
     def _compute_attr_value_from_expr(expr, ci_dict):
-        result = jinja2.Template(expr).render(ci_dict)
         try:
-            return ast.literal_eval(result)
+            result = jinja2.Template(expr).render(ci_dict)
+            return result
         except Exception as e:
             current_app.logger.warning(
-                f"Expression evaluation error - Expression: '{expr}', Rendered result: '{result}', "
+                f"Expression evaluation error - Expression: '{expr}'"
                 f"Input parameters: {ci_dict}, Error type: {type(e).__name__}, Error message: {str(e)}"
             )
-
+            return None
     @staticmethod
     def _compute_attr_value_from_script(script, ci_dict):
         script = jinja2.Template(script).render(ci_dict)


### PR DESCRIPTION
原有的代码中，eval的本意可能是将jinja2返回的str变成合适的类型，但实际上会带来如下问题:
1. 安全隐患太大，相对于_compute_attr_value_from_script，_compute_attr_value_from_expr是可以接受普通用户输入的（导入CI时填充高危命令）），如果传入 高危命令，影响比较大
2. 优化处理效率
但本次修改也可能带来一定影响，主要是取消了eval兜底，原先配置的，不符合jinja2规范的代码没有办法继续生效了。