### PR TITLE
fix wehook trigger ok when http status failed

### DIFF
--- a/cmdb-api/api/commands/click_cmdb.py
+++ b/cmdb-api/api/commands/click_cmdb.py
@@ -255,7 +255,9 @@ def cmdb_trigger():
                     try:
                         ready_cis = CITriggerManager.waiting_cis(trigger)
                     except Exception as e:
-                        print(e)
+                        import traceback
+                        current_app.logger.error("cmdb trigger waiting_cis exception for trigger_id {}: {}".format(trigger.id, e))
+                        current_app.logger.error("traceback: {}".format(traceback.format_exc()))
                         continue
 
                     if trigger.id not in trigger2cis:

--- a/cmdb-api/api/lib/cmdb/ci.py
+++ b/cmdb-api/api/lib/cmdb/ci.py
@@ -1618,7 +1618,8 @@ class CITriggerManager(object):
                     ci_id, need_children=False, use_master=False, enum_use_label=True)
 
             try:
-                response = webhook_request(webhook, ci_dict).text
+                response = webhook_request(webhook, ci_dict)
+                response.raise_for_status()
                 is_ok = True
             except Exception as e:
                 current_app.logger.warning("exec webhook failed: {}".format(e))


### PR DESCRIPTION
Currently, the trigger status failed only when the webhook host network failure, but the webhook failed with status code 502 or 404, the trigger is also ok.