### PR TITLE
security: mask root token output by default

### DIFF
--- a/cmdb-api/api/lib/secrets/inner.py
+++ b/cmdb-api/api/lib/secrets/inner.py
@@ -369,7 +369,13 @@ class KeyManage:
                 "unseal token " + str(i + 1) + ": " + Fore.RED + Back.BLACK + v.decode("utf-8") + Style.RESET_ALL)
             print()
 
-        print(Fore.GREEN + "root token:  " + root_token.decode("utf-8") + Style.RESET_ALL)
+        show_root_token = str(os.environ.get("CMDB_SHOW_ROOT_TOKEN_ON_INIT", "")).lower() == "true"
+        if show_root_token:
+            print(Fore.GREEN + "root token:  " + root_token.decode("utf-8") + Style.RESET_ALL)
+        else:
+            token = root_token.decode("utf-8")
+            masked = "{0}...{1}".format(token[:4], token[-4:]) if len(token) > 8 else "********"
+            print(Fore.GREEN + "root token (masked):  " + masked + Style.RESET_ALL)
 
     @classmethod
     def print_response(cls, data):


### PR DESCRIPTION
## Summary
Secret initialization flow printed full root token to console logs/stdout.

## Security Fix
Mask token by default and only print full token when explicit env switch is enabled.

## Linked Issue
Closes #753
https://github.com/veops/cmdb/issues/753

## Commit
1be0610