### PR TITLE
security: require vault token via environment variable

### DIFF
--- a/cmdb-api/api/lib/secrets/vault.py
+++ b/cmdb-api/api/lib/secrets/vault.py
@@ -2,6 +2,7 @@ from base64 import b64decode
 from base64 import b64encode
 
 import hvac
+import os
 
 
 class VaultClient:
@@ -128,7 +129,9 @@ class VaultClient:
 
 if __name__ == "__main__":
     _base_url = "http://localhost:8200"
-    _token = "your token"
+    _token = os.environ.get("VAULT_TOKEN", "")
+    if not _token:
+        raise RuntimeError("VAULT_TOKEN is required")
 
     _path = "test001"
     # Example


### PR DESCRIPTION
## Summary
Vault example path included a hardcoded token placeholder that can lead to unsafe copy/paste usage.

## Security Fix
Require VAULT_TOKEN from environment and fail fast when missing.

## Linked Issue
Closes #755
https://github.com/veops/cmdb/issues/755

## Commit
8ad38f8