### PR TITLE
security: remove unsafe html rendering in notice and metadata views

### DIFF
--- a/cmdb-ui/src/modules/cmdb/views/ci/modules/MetadataDrawer.vue
+++ b/cmdb-ui/src/modules/cmdb/views/ci/modules/MetadataDrawer.vue
@@ -56,14 +56,13 @@
                   { label: $t('no'), value: false },
                 ]
           "
-          type="html"
         >
           <template #default="{ row }">
             <span v-if="column.field !== 'name' && column.field !== 'alias' && column.field !== 'value_type'">
               <a-icon :style="{ color: '#1fb51f' }" type="check" v-if="row[column.field]" />
             </span>
-            <span v-else-if="column.field === 'value_type'" v-html="valueTypeMap[row.value_type]"> </span>
-            <span v-else v-html="row[column.field]"> </span>
+            <span v-else-if="column.field === 'value_type'">{{ valueTypeMap[row.value_type] }}</span>
+            <span v-else>{{ row[column.field] }}</span>
           </template>
         </vxe-column>
       </vxe-table>
@@ -196,9 +195,8 @@ export default {
         .trim()
         .toLowerCase()
       if (filterName) {
-        const filterRE = new RegExp(filterName, 'gi')
         const searchProps = ['name', 'alias', 'value_type']
-        const rest = this.tableData.filter((item) =>
+        this.list = this.tableData.filter((item) =>
           searchProps.some(
             (key) =>
               XEUtils.toValueString(item[key])
@@ -206,16 +204,6 @@ export default {
                 .indexOf(filterName) > -1
           )
         )
-        this.list = rest.map((row) => {
-          const item = Object.assign({}, row)
-          searchProps.forEach((key) => {
-            item[key] = XEUtils.toValueString(item[key]).replace(
-              filterRE,
-              (match) => `<span style='background: yellow'>${match}</span>`
-            )
-          })
-          return item
-        })
       } else {
         this.list = this.tableData
       }

--- a/cmdb-ui/src/views/noticeCenter/index.vue
+++ b/cmdb-ui/src/views/noticeCenter/index.vue
@@ -85,7 +85,7 @@
         <vxe-column type="checkbox" width="60px"></vxe-column>
         <vxe-column field="content" title="标题内容">
           <template #default="{row}">
-            <span v-html="row.content"></span>
+            <span>{{ row.content }}</span>
           </template>
         </vxe-column>
         <vxe-column field="created_at" title="提交时间" width="150px">


### PR DESCRIPTION
## Summary
UI rendered potentially untrusted content via v-html and HTML cell mode in user-facing tables.

## Security Fix
Switch rendering to safe text output and remove HTML-only rendering mode in these views.

## Linked Issue
Closes #757
https://github.com/veops/cmdb/issues/757

## Commit
3b68276