### PR TITLE
security: replace weak sample db credentials in env

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
- MYSQL_ROOT_PASSWORD='123456'
+ MYSQL_ROOT_PASSWORD='change_me_strong_root_password'
  MYSQL_HOST='mysql'
  MYSQL_PORT=3306
  MYSQL_USER='cmdb'
  MYSQL_DATABASE='cmdb'
- MYSQL_PASSWORD='123456'
+ MYSQL_PASSWORD='change_me_strong_db_password'


### PR DESCRIPTION
## Summary
Sample env file used extremely weak default DB credentials.

## Security Fix
Replace defaults with strong placeholders requiring explicit secure values.

## Linked Issue
Closes #763
https://github.com/veops/cmdb/issues/763

## Commit
63eb9bf